### PR TITLE
geom_alt props

### DIFF
--- a/data/856/325/51/85632551.geojson
+++ b/data/856/325/51/85632551.geojson
@@ -958,6 +958,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1012,6 +1013,10 @@
     },
     "wof:country":"KN",
     "wof:country_alpha3":"KNA",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"36822a68ea4f1626c05778f24e62484d",
     "wof:hierarchy":[
         {
@@ -1026,7 +1031,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566581613,
+    "wof:lastmodified":1582347049,
     "wof:name":"Saint Kitts and Nevis",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/325/51/85632551.geojson
+++ b/data/856/325/51/85632551.geojson
@@ -958,7 +958,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1031,7 +1030,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1582347049,
+    "wof:lastmodified":1583226662,
     "wof:name":"Saint Kitts and Nevis",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/890/440/079/890440079.geojson
+++ b/data/890/440/079/890440079.geojson
@@ -448,6 +448,9 @@
     },
     "wof:country":"KN",
     "wof:created":1469052261,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"2be6a1c1aadbc58f760c6c317d13f309",
     "wof:hierarchy":[
         {
@@ -458,7 +461,7 @@
         }
     ],
     "wof:id":890440079,
-    "wof:lastmodified":1566581621,
+    "wof:lastmodified":1582347049,
     "wof:name":"Basseterre",
     "wof:parent_id":85673167,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.