### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/586/871/9/1125868719.geojson
+++ b/data/112/586/871/9/1125868719.geojson
@@ -40,6 +40,9 @@
     "name:ita_x_preferred":[
         "Cotton Ground"
     ],
+    "name:jpn_x_preferred":[
+        "\u30b3\u30c3\u30c8\u30f3\u30fb\u30b0\u30e9\u30a6\u30f3\u30c9"
+    ],
     "name:mkd_x_preferred":[
         "\u041a\u043e\u0442\u043e\u043d \u0413\u0440\u0430\u0443\u043d\u0434"
     ],
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":1125868719,
-    "wof:lastmodified":1566581621,
+    "wof:lastmodified":1690938200,
     "wof:name":"Cotton Ground",
     "wof:parent_id":85673161,
     "wof:placetype":"locality",

--- a/data/421/178/165/421178165.geojson
+++ b/data/421/178/165/421178165.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Saddlers"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0430\u0434\u043b\u0435\u0440\u0441"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0633\u062f\u0644\u0631\u0632"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b5\u30c9\u30e9\u30fc\u30ba"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0435\u0434\u043b\u0435\u0440\u0441"
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421178165,
-    "wof:lastmodified":1566581620,
+    "wof:lastmodified":1690938198,
     "wof:name":"Saunders",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/181/065/421181065.geojson
+++ b/data/421/181/065/421181065.geojson
@@ -17,14 +17,23 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:deu_x_preferred":[
+        "Challengers"
+    ],
     "name:eng_x_preferred":[
         "Challengers"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c1\u30e3\u30ec\u30f3\u30b8\u30e3\u30fc\u30ba"
     ],
     "name:nld_x_preferred":[
         "Challengers"
     ],
     "name:und_x_variant":[
         "Challengers Village"
+    ],
+    "name:zho_x_preferred":[
+        "\u67e5\u4f26\u6770\u65af"
     ],
     "qs:gn_country":"KN",
     "qs:gn_fcode":"PPL",
@@ -66,7 +75,7 @@
         }
     ],
     "wof:id":421181065,
-    "wof:lastmodified":1566581619,
+    "wof:lastmodified":1690938198,
     "wof:name":"Challengers",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/182/307/421182307.geojson
+++ b/data/421/182/307/421182307.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0634\u0627\u0631\u0644\u0633\u062a\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0627\u0631\u0644\u0633\u062a\u064a\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "\u00c7arlstaun"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0427\u0430\u0440\u043b\u044c\u0437\u0442\u0430\u045e\u043d"
     ],
@@ -56,6 +62,9 @@
     "name:fra_x_preferred":[
         "Charlestown"
     ],
+    "name:gle_x_preferred":[
+        "Charlestown"
+    ],
     "name:hbs_x_preferred":[
         "Charlestown"
     ],
@@ -63,6 +72,12 @@
         "\u05e6'\u05d0\u05e8\u05dc\u05e1\u05d8\u05d0\u05d5\u05df"
     ],
     "name:hun_x_preferred":[
+        "Charlestown"
+    ],
+    "name:hye_x_preferred":[
+        "\u0549\u0561\u0580\u056c\u0566\u0569\u0561\u0578\u0582\u0576"
+    ],
+    "name:ind_x_preferred":[
         "Charlestown"
     ],
     "name:ita_x_preferred":[
@@ -162,7 +177,7 @@
         }
     ],
     "wof:id":421182307,
-    "wof:lastmodified":1566581620,
+    "wof:lastmodified":1690938199,
     "wof:name":"Charlestown",
     "wof:parent_id":85673153,
     "wof:placetype":"locality",

--- a/data/421/184/519/421184519.geojson
+++ b/data/421/184/519/421184519.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Mannings"
     ],
+    "name:deu_x_preferred":[
+        "Mannings"
+    ],
     "name:eng_x_preferred":[
         "Mannings"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:zho_x_preferred":[
         "\u842c\u5be7"
+    ],
+    "name:zho_x_variant":[
+        "\u66fc\u5b81\u65af"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -84,7 +90,7 @@
         }
     ],
     "wof:id":421184519,
-    "wof:lastmodified":1566581620,
+    "wof:lastmodified":1690938198,
     "wof:name":"Mannings",
     "wof:parent_id":85673131,
     "wof:placetype":"locality",

--- a/data/421/186/519/421186519.geojson
+++ b/data/421/186/519/421186519.geojson
@@ -32,6 +32,9 @@
     "name:fas_x_preferred":[
         "\u0645\u0627\u0646\u06a9\u06cc \u0647\u06cc\u0644"
     ],
+    "name:ita_x_preferred":[
+        "Monkey Hill"
+    ],
     "name:jpn_x_preferred":[
         "\u30e2\u30f3\u30ad\u30fc\u30d2\u30eb"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:pol_x_preferred":[
         "Monkey Hill"
+    ],
+    "name:por_x_preferred":[
+        "Monkey Hill Village"
     ],
     "name:spa_x_preferred":[
         "Monkey Hill"
@@ -109,7 +115,7 @@
         }
     ],
     "wof:id":421186519,
-    "wof:lastmodified":1566581619,
+    "wof:lastmodified":1690938197,
     "wof:name":"Monkey Hill",
     "wof:parent_id":85673121,
     "wof:placetype":"locality",

--- a/data/421/186/521/421186521.geojson
+++ b/data/421/186/521/421186521.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062f\u064a \u0628\u0648\u064a\u0646\u062a \u062a\u0627\u0648\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Sandy Point Town"
+    ],
     "name:ceb_x_preferred":[
         "Sandy Point Town"
     ],
@@ -29,8 +32,14 @@
     "name:eng_x_preferred":[
         "Sandy Point Town"
     ],
+    "name:fra_x_preferred":[
+        "Sandy Point Town"
+    ],
     "name:heb_x_preferred":[
         "\u05e1\u05e0\u05d3\u05d9 \u05e4\u05d5\u05d9\u05e0\u05d8"
+    ],
+    "name:ita_x_preferred":[
+        "Sandy Point Town"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30c7\u30a3\u30fb\u30dd\u30a4\u30f3\u30c8"
@@ -43,6 +52,9 @@
     ],
     "name:pol_x_preferred":[
         "Sandy Point"
+    ],
+    "name:por_x_preferred":[
+        "Sandy Point Town"
     ],
     "name:rus_x_preferred":[
         "\u0421\u044d\u043d\u0434\u0438-\u041f\u043e\u0439\u043d\u0442-\u0422\u0430\u0443\u043d"
@@ -99,7 +111,7 @@
         }
     ],
     "wof:id":421186521,
-    "wof:lastmodified":1566581619,
+    "wof:lastmodified":1690938197,
     "wof:name":"Sandy Point Town",
     "wof:parent_id":85673117,
     "wof:placetype":"locality",

--- a/data/421/186/525/421186525.geojson
+++ b/data/421/186/525/421186525.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u064a\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u064a\u0648\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Cayon"
+    ],
     "name:ceb_x_preferred":[
         "Cayon"
     ],
@@ -40,6 +46,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d0\u05d9\u05d5\u05df"
+    ],
+    "name:ita_x_preferred":[
+        "Cayon"
     ],
     "name:jpn_x_preferred":[
         "\u30b1\u30a4\u30aa\u30f3"
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":421186525,
-    "wof:lastmodified":1566581619,
+    "wof:lastmodified":1690938197,
     "wof:name":"Cayon",
     "wof:parent_id":85673143,
     "wof:placetype":"locality",

--- a/data/421/187/299/421187299.geojson
+++ b/data/421/187/299/421187299.geojson
@@ -29,6 +29,12 @@
     "name:eng_x_preferred":[
         "Tabernacle"
     ],
+    "name:ita_x_preferred":[
+        "Tabernacle"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30bf\u30d0\u30cd\u30fc\u30af\u30eb"
+    ],
     "name:nld_x_preferred":[
         "Tabernacle"
     ],
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":421187299,
-    "wof:lastmodified":1566581618,
+    "wof:lastmodified":1690938197,
     "wof:name":"Tabernacle",
     "wof:parent_id":85673111,
     "wof:placetype":"locality",

--- a/data/421/192/739/421192739.geojson
+++ b/data/421/192/739/421192739.geojson
@@ -32,6 +32,12 @@
     "name:fra_x_preferred":[
         "Figtree"
     ],
+    "name:ita_x_preferred":[
+        "Figtree"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d5\u30a3\u30b0\u30c4\u30ea\u30fc"
+    ],
     "name:mkd_x_preferred":[
         "\u0424\u0438\u0433\u0442\u0440\u0438"
     ],
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421192739,
-    "wof:lastmodified":1566581618,
+    "wof:lastmodified":1690938196,
     "wof:name":"Fig Tree",
     "wof:parent_id":85673139,
     "wof:placetype":"locality",

--- a/data/421/199/471/421199471.geojson
+++ b/data/421/199/471/421199471.geojson
@@ -17,8 +17,17 @@
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:azb_x_preferred":[
+        "\u0639\u0645\u0627\u0631\u062a"
+    ],
     "name:bel_x_preferred":[
         "\u0410\u0441\u0430\u0431\u043d\u044f\u043a"
+    ],
+    "name:bel_x_variant":[
+        "\u0430\u0441\u0430\u0431\u043d\u044f\u043a"
+    ],
+    "name:ben_x_preferred":[
+        "\u0985\u099f\u09cd\u099f\u09be\u09b2\u09bf\u0995\u09be"
     ],
     "name:cat_x_preferred":[
         "Mansi\u00f3"
@@ -28,6 +37,9 @@
     ],
     "name:cym_x_preferred":[
         "plasty"
+    ],
+    "name:dag_x_preferred":[
+        "Yili titali"
     ],
     "name:dan_x_preferred":[
         "landsted"
@@ -44,6 +56,12 @@
     "name:eng_x_preferred":[
         "mansion"
     ],
+    "name:epo_x_preferred":[
+        "domego"
+    ],
+    "name:eus_x_preferred":[
+        "luxuzko etxe"
+    ],
     "name:fas_x_preferred":[
         "\u0639\u0645\u0627\u0631\u062a"
     ],
@@ -56,6 +74,9 @@
     "name:fra_x_variant":[
         "maison bourgeoise"
     ],
+    "name:gle_x_preferred":[
+        "teach m\u00f3r"
+    ],
     "name:heb_x_preferred":[
         "\u05d0\u05d7\u05d5\u05d6\u05d4"
     ],
@@ -67,6 +88,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0574\u0565\u056e \u0561\u057c\u0561\u0576\u0571\u0576\u0561\u057f\u0578\u0582\u0576"
+    ],
+    "name:ind_x_preferred":[
+        "Wastu"
     ],
     "name:ita_x_preferred":[
         "Magione"
@@ -83,14 +107,29 @@
     "name:kor_x_preferred":[
         "\uc800\ud0dd"
     ],
+    "name:lav_x_preferred":[
+        "savrupm\u0101ja"
+    ],
+    "name:ltz_x_preferred":[
+        "H\u00e4renhaus"
+    ],
     "name:mkd_x_preferred":[
         "\u0412\u0435\u043b\u0435\u043f\u043e\u0441\u0435\u0434\u043d\u0438\u0447\u043a\u0430 \u043a\u0443\u045c\u0430"
     ],
     "name:mkd_x_variant":[
         "\u0432\u0435\u043b\u0435\u043f\u043e\u0441\u0435\u0434\u043d\u0438\u0447\u043a\u0430 \u043a\u0443\u045c\u0430"
     ],
+    "name:msa_x_preferred":[
+        "rumah agam"
+    ],
     "name:nld_x_preferred":[
         "landhuis"
+    ],
+    "name:nob_x_preferred":[
+        "lystg\u00e5rd"
+    ],
+    "name:pol_x_preferred":[
+        "rezydencja"
     ],
     "name:por_x_preferred":[
         "Mans\u00e3o"
@@ -140,8 +179,17 @@
     "name:ukr_x_preferred":[
         "\u041e\u0441\u043e\u0431\u043d\u044f\u043a"
     ],
+    "name:ukr_x_variant":[
+        "\u043e\u0441\u043e\u0431\u043d\u044f\u043a"
+    ],
+    "name:vec_x_preferred":[
+        "mansion"
+    ],
     "name:vie_x_preferred":[
         "Dinh th\u1ef1"
+    ],
+    "name:vie_x_variant":[
+        "dinh th\u1ef1"
     ],
     "name:zho_x_preferred":[
         "\u5b85\u7b2c"
@@ -191,7 +239,7 @@
         }
     ],
     "wof:id":421199471,
-    "wof:lastmodified":1566581619,
+    "wof:lastmodified":1690938198,
     "wof:name":"Mansion",
     "wof:parent_id":85673111,
     "wof:placetype":"locality",

--- a/data/421/201/337/421201337.geojson
+++ b/data/421/201/337/421201337.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0646\u064a\u0648\u0643\u0627\u0633\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u064a\u0648\u0643\u0627\u0633\u0644"
+    ],
     "name:ceb_x_preferred":[
         "Newcastle"
     ],
@@ -37,6 +40,12 @@
     ],
     "name:heb_x_preferred":[
         "\u05e0\u05d9\u05d5\u05e7\u05d0\u05e1\u05dc"
+    ],
+    "name:ita_x_preferred":[
+        "Newcastle"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30cb\u30e5\u30fc\u30ab\u30c3\u30b9\u30eb"
     ],
     "name:lit_x_preferred":[
         "Niukaslas"
@@ -70,6 +79,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7d10\u5361\u65af\u723e"
+    ],
+    "name:zho_x_variant":[
+        "\u7ebd\u5361\u65af\u5c14"
     ],
     "qs:gn_country":"KN",
     "qs:gn_fcode":"PPL",
@@ -117,7 +129,7 @@
         }
     ],
     "wof:id":421201337,
-    "wof:lastmodified":1566581620,
+    "wof:lastmodified":1690938198,
     "wof:name":"Newcastle",
     "wof:parent_id":85673131,
     "wof:placetype":"locality",

--- a/data/421/204/467/421204467.geojson
+++ b/data/421/204/467/421204467.geojson
@@ -35,6 +35,12 @@
     "name:fra_x_preferred":[
         "Middle Island"
     ],
+    "name:ita_x_preferred":[
+        "Middle Island"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30df\u30c9\u30eb\u30a2\u30a4\u30e9\u30f3\u30c9"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0438\u0434\u043b \u0410\u0458\u043b\u0430\u043d\u0434"
     ],
@@ -102,7 +108,7 @@
         }
     ],
     "wof:id":421204467,
-    "wof:lastmodified":1566581618,
+    "wof:lastmodified":1690938197,
     "wof:name":"Middle Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/325/51/85632551.geojson
+++ b/data/856/325/51/85632551.geojson
@@ -37,6 +37,9 @@
     "name:aka_x_preferred":[
         "Saint Kitts ne N\u025bves"
     ],
+    "name:aka_x_variant":[
+        "Saint Kitts and Nevis"
+    ],
     "name:als_x_preferred":[
         "St. Kitts und Nevis"
     ],
@@ -46,11 +49,20 @@
     "name:amh_x_variant":[
         "\u1245\u12f1\u1235 \u12aa\u1275\u1235 \u12a5\u1293 \u1294\u126a\u1235"
     ],
+    "name:ang_x_preferred":[
+        "Sanctus-Christophes and Nefis"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u0947\u0902\u091f \u0915\u093f\u091f\u094d\u0938 \u0906\u0930\u094b \u0928\u0947\u0935\u093f\u0938"
+    ],
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0643\u064a\u062a\u0633 \u0648\u0646\u064a\u0641\u064a\u0633"
     ],
     "name:arg_x_preferred":[
         "Sant Cristofo y Nieus"
+    ],
+    "name:ary_x_preferred":[
+        "\u0633\u0627\u0646 \u0643\u064a\u062a\u0633 \u0624\u0646\u064a\u06a4\u064a\u0633"
     ],
     "name:arz_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0643\u064a\u062a\u0633 \u0648 \u0646\u064a\u06a4\u064a\u0633"
@@ -79,6 +91,9 @@
     "name:bam_x_preferred":[
         "Krist\u0254fo-Senu-ni-\u019dev\u025bs"
     ],
+    "name:ban_x_preferred":[
+        "Saint Kitts miwah N\u00e9vis"
+    ],
     "name:bar_x_preferred":[
         "St. Kitts und Nevis"
     ],
@@ -97,6 +112,9 @@
     ],
     "name:ben_x_variant":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u0995\u09bf\u099f\u09b8 \u0993 \u09a8\u09c7\u09ad\u09bf\u09b8"
+    ],
+    "name:bis_x_preferred":[
+        "Sen Kit mo Nevis"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f7a\u0f53\u0f0b\u0f4a\u0f72\u0f0b\u0f40\u0f72\u0f0b\u0f4a\u0f72\u0f0b\u0f66\u0f72\u0f0b\u0f51\u0f44\u0f0b\u0f53\u0f7a\u0f0b\u0f56\u0f72\u0f0b\u0f66\u0f72\u0f0d"
@@ -174,6 +192,9 @@
         "Sv. Kitts a Nevis",
         "Svat\u00fd Kitts a Nevis"
     ],
+    "name:dag_x_preferred":[
+        "Saint Kitts & Nevis"
+    ],
     "name:dan_x_preferred":[
         "Saint Kitts og Nevis"
     ],
@@ -187,6 +208,9 @@
     "name:deu_x_variant":[
         "F\u00f6deration St. Kitts und Nevis",
         "Saint Kitts und Nevis"
+    ],
+    "name:diq_x_preferred":[
+        "Saint Kitts u Nevis"
     ],
     "name:div_x_preferred":[
         "\u0790\u07a6\u0782\u07b0\u078c\u07a8 \u0786\u07a8\u0793\u07a6\u0790\u07b0 \u0787\u07a6\u078b\u07a8 \u0782\u07ad\u0788\u07a9\u0790\u07b0"
@@ -284,6 +308,9 @@
     "name:ful_x_preferred":[
         "Sent Kits e Newis"
     ],
+    "name:gag_x_preferred":[
+        "Sent Kitts hem Nevis"
+    ],
     "name:gla_x_preferred":[
         "Naomh Cr\u00ecstean agus Nibheis"
     ],
@@ -304,6 +331,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0938\u0947\u0902\u091f \u0915\u093f\u091f\u094d\u0938 \u0906\u0923\u093f \u0928\u0947\u0935\u094d\u0939\u093f\u0938"
+    ],
+    "name:gpe_x_preferred":[
+        "Saint Kitts and Nevis"
     ],
     "name:grn_x_preferred":[
         "San Crist\u00f3bal ha Nieves"
@@ -328,6 +358,9 @@
     ],
     "name:hau_x_preferred":[
         "San Kiti Da Nebis"
+    ],
+    "name:hau_x_variant":[
+        "Saint Kitts da Nevis"
     ],
     "name:hbs_x_preferred":[
         "Sveti Kristofor i Nevis"
@@ -367,6 +400,9 @@
     "name:hye_x_variant":[
         "\u054d\u0565\u0576\u057f \u053f\u056b\u057f\u057d-\u0546\u0565\u057e\u056b\u057d"
     ],
+    "name:hyw_x_preferred":[
+        "\u054d\u0567\u0575\u0576\u0569 \u0554\u056b\u0569\u057d \u0565\u0582 \u0546\u0565\u0582\u056b\u057d"
+    ],
     "name:ido_x_preferred":[
         "Santa Kitts e Nevis"
     ],
@@ -378,6 +414,9 @@
     ],
     "name:ina_x_preferred":[
         "Sancte Christophoro e Nevis"
+    ],
+    "name:ina_x_variant":[
+        "Sancte Kitts e Nevis"
     ],
     "name:ind_x_preferred":[
         "Saint Kitts dan Nevis"
@@ -415,6 +454,9 @@
         "\u30bb\u30f3\u30c8\u30ad\u30c3\u30c4\u30fb\u30cd\u30a4\u30d3\u30b9",
         "\u30bb\u30f3\u30c8\u30af\u30ea\u30b9\u30c8\u30d5\u30a1\u30fc\u30fb\u30cd\u30d3\u30b9",
         "\u30bb\u30f3\u30c8\u30af\u30ea\u30b9\u30c8\u30d5\u30a1\u30fc\u30fb\u30cd\u30fc\u30f4\u30a3\u30b9"
+    ],
+    "name:kaa_x_preferred":[
+        "Sent-Kitts ha'm Nevis"
     ],
     "name:kab_x_preferred":[
         "Saint Kitts ed Nevis"
@@ -484,6 +526,9 @@
     "name:lit_x_variant":[
         "Sent Kristoferis ir Nevis"
     ],
+    "name:lld_x_preferred":[
+        "San Cristoful y Nevis"
+    ],
     "name:lmo_x_preferred":[
         "Saint Kitts e Nevis"
     ],
@@ -496,6 +541,9 @@
     "name:lug_x_preferred":[
         "Senti Kitisi ne Nevisi"
     ],
+    "name:mad_x_preferred":[
+        "Saint Kitts b\u00e2n Nevis"
+    ],
     "name:mal_x_preferred":[
         "\u0d38\u0d46\u0d2f\u0d4d\u0d28\u0d4d\u0d31\u0d4d \u0d15\u0d3f\u0d31\u0d4d\u0d31\u0d4d\u0d38\u0d4d \u0d28\u0d40\u0d35\u0d38\u0d4d"
     ],
@@ -504,6 +552,15 @@
     ],
     "name:mar_x_preferred":[
         "\u0938\u0947\u0902\u091f \u0915\u093f\u091f\u094d\u0938 \u0906\u0923\u093f \u0928\u0947\u0935\u094d\u0939\u093f\u0938"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0421\u044d\u043d\u0442-\u041a\u0438\u0442\u0441 \u0434\u0438 \u041d\u044d\u0432\u0438\u0441"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u041a\u0438\u0442\u0441 \u0434\u0430 \u041d\u0435\u0432\u0438\u0441"
+    ],
+    "name:min_x_preferred":[
+        "Saint Kitts jo Nevis"
     ],
     "name:mkd_x_preferred":[
         "\u0421\u0432\u0435\u0442\u0438 \u041a\u0440\u0438\u0441\u0442\u043e\u0444\u0435\u0440 \u0438 \u041d\u0435\u0432\u0438\u0441"
@@ -523,8 +580,14 @@
     "name:mlt_x_variant":[
         "Saint Kitts and Nevis"
     ],
+    "name:mni_x_preferred":[
+        "\uabc1\uabe6\uabdf\uabe0 \uabc0\uabe4\uabe0\uabc1 \uabd1\uabc3\uabd7\uabe4 \uabc5\uabe6\uabda\uabe4\uabc1"
+    ],
     "name:mon_x_preferred":[
         "\u0421\u0435\u043d\u0442-\u041a\u0438\u0442\u0441 \u0431\u0430 \u041d\u0435\u0432\u0438\u0441"
+    ],
+    "name:mri_x_preferred":[
+        "H\u0101to Kete"
     ],
     "name:msa_x_preferred":[
         "Santo Kitts dan Nevis"
@@ -633,7 +696,8 @@
     "name:por_x_variant":[
         "Saint Kitts e Nevis",
         "S\u00e3o Cristov\u00e3o e Nevis",
-        "S\u00e3o Crist\u00f3v\u00e3o e N\u00e9vis"
+        "S\u00e3o Crist\u00f3v\u00e3o e N\u00e9vis",
+        "S\u00e3o Crist\u00f3v\u00e3o e Neves"
     ],
     "name:pus_x_preferred":[
         "\u0633\u06d0\u0646\u067c \u06a9\u06d0\u067c\u0633 \u0627\u0648 \u0646\u06d0\u0648\u064a\u0633"
@@ -685,6 +749,9 @@
     "name:sgs_x_preferred":[
         "Sent Kitsos \u0117r Nevis"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101e\u1035\u1004\u103a\u1089\u1076\u102d\u1010\u103a\u1088 \u101c\u1084\u1088 \u107c\u1084\u1038\u101d\u102d\u1010\u103a"
+    ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0d9a\u0dd2\u0da7\u0dca\u0dc3\u0dca \u0dc3\u0dc4 \u0db1\u0dd9\u0dc0\u0dd2\u0dc3\u0dca"
     ],
@@ -708,8 +775,20 @@
     "name:sme_x_variant":[
         "Saint Kitts ja Nevis"
     ],
+    "name:smn_x_preferred":[
+        "Saint Kitts j\u00e1 Nevis"
+    ],
+    "name:smo_x_preferred":[
+        "Saint Kitts ma Nevis"
+    ],
+    "name:sms_x_preferred":[
+        "Saint Kitts da Nevis"
+    ],
     "name:sna_x_preferred":[
         "Saint Kitts and Nevis"
+    ],
+    "name:snd_x_preferred":[
+        "\u0633\u064a\u0646\u067d \u06aa\u067d\u0633 \u06fd \u0646\u064a\u0648\u0633"
     ],
     "name:som_x_preferred":[
         "Saint Kitts and Nevis"
@@ -729,6 +808,9 @@
         "Sh\u00ebn Kits dhe Nevis"
     ],
     "name:sqi_x_variant":[
+        "Saint Kitts e Nevis"
+    ],
+    "name:srd_x_preferred":[
         "Saint Kitts e Nevis"
     ],
     "name:srp_x_preferred":[
@@ -772,6 +854,9 @@
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c02\u0c1f\u0c4d \u0c15\u0c3f\u0c1f\u0c4d\u0c1f\u0c4d\u0c38\u0c4d \u0c2e\u0c30\u0c3f\u0c2f\u0c41 \u0c28\u0c46\u0c35\u0c3f\u0c38\u0c4d"
     ],
+    "name:tel_x_variant":[
+        "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c15\u0c3f\u0c1f\u0c4d\u0c38\u0c4d \u0c05\u0c02\u0c21\u0c4d \u0c28\u0c46\u0c35\u0c3f\u0c38\u0c4d"
+    ],
     "name:tet_x_preferred":[
         "Saun Krist\u00f3vaun no Neves"
     ],
@@ -797,11 +882,17 @@
     "name:ton_x_preferred":[
         "Seini Kitisi mo Nevisi"
     ],
+    "name:ton_x_variant":[
+        "S\u0101 Kitisi mo Nevisi"
+    ],
     "name:tuk_x_preferred":[
         "Sent-Kits we Newis"
     ],
     "name:tur_x_preferred":[
         "Saint Kitts ve Nevis"
+    ],
+    "name:udm_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u041a\u0438\u0442\u0441 \u043d\u043e \u041d\u0435\u0432\u0438\u0441"
     ],
     "name:uig_x_preferred":[
         "\u0633\u06d0\u0646\u062a \u0643\u0649\u062a\u0633 \u06cb\u06d5 \u0646\u06d0\u06cb\u0649\u0633"
@@ -825,6 +916,9 @@
     ],
     "name:uzb_x_preferred":[
         "Saint Kitts va Nevis"
+    ],
+    "name:vec_x_preferred":[
+        "Saint Kitts e Nevis"
     ],
     "name:vep_x_preferred":[
         "Sent Kits da Nevis"
@@ -1096,7 +1190,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827544,
+    "wof:lastmodified":1690938196,
     "wof:name":"Saint Kitts and Nevis",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/731/11/85673111.geojson
+++ b/data/856/731/11/85673111.geojson
@@ -65,6 +65,9 @@
     "name:fra_x_preferred":[
         "Christ Church Nichola Town"
     ],
+    "name:frr_x_preferred":[
+        "Christ Church Nichola Town"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0acd\u0ab0\u0abf\u0ab8\u0acd\u0a9f \u0a9a\u0ab0\u0acd\u0a9a \u0aa8\u0abf\u0a95\u0acb\u0ab2\u0abe \u0a9f\u0abe\u0a89\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -112,6 +115,9 @@
     ],
     "name:nob_x_preferred":[
         "Christ Church Nichola Town prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Christ Church Nichola Town"
     ],
     "name:nor_x_preferred":[
         "Christ Church Nichola Town prestegjeld"
@@ -279,7 +285,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501336,
+    "wof:lastmodified":1690938193,
     "wof:name":"Christ Church Nichola Town",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/17/85673117.geojson
+++ b/data/856/731/17/85673117.geojson
@@ -67,6 +67,9 @@
     "name:fra_x_preferred":[
         "Saint-Anne Sandy Point"
     ],
+    "name:frr_x_preferred":[
+        "Saint Anne Sandy Point"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a8f\u0aa8 \u0ab8\u0ac7\u0aa8\u0acd\u0aa1\u0ac0 \u0aaa\u0acb\u0a87\u0aa8\u0acd\u0a9f \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -114,6 +117,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Anne Sandy Point prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Anne Sandy Point"
     ],
     "name:nor_x_preferred":[
         "Saint Anne Sandy Point prestegjeld"
@@ -281,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501337,
+    "wof:lastmodified":1690938194,
     "wof:name":"Saint Anne Sandy Point",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/21/85673121.geojson
+++ b/data/856/731/21/85673121.geojson
@@ -67,6 +67,9 @@
     "name:fra_x_preferred":[
         "Saint-George Basseterre"
     ],
+    "name:frr_x_preferred":[
+        "Saint George Basseterre"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a82\u0a9f \u0a9c\u0acd\u0aaf\u0acb\u0ab0\u0acd\u0a9c \u0aac\u0abe\u0ab8\u0ac7\u0a9f\u0ac7\u0ab0 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -94,6 +97,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc870\uc9c0\ubc14\uc2a4\ud14c\ub974 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc870\uc9c0\ubc14\uc2a4\ud14c\ub974\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eord\u017ea Bastera pagasts"
     ],
@@ -114,6 +120,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint George Basseterre prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint George Basseterre"
     ],
     "name:nor_x_preferred":[
         "Saint George Basseterre prestegjeld"
@@ -159,6 +168,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8056\u55ac\u6cbb\u5df4\u585e\u7279\u840a\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u5723\u4e54\u6cbb\u5df4\u65af\u7279\u5c14\u533a"
     ],
     "ne:abbrev":"GBA",
     "ne:adm0_a3":"KNA",
@@ -281,7 +293,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501337,
+    "wof:lastmodified":1690938194,
     "wof:name":"Saint George Basseterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/25/85673125.geojson
+++ b/data/856/731/25/85673125.geojson
@@ -64,6 +64,9 @@
     "name:fra_x_preferred":[
         "Saint-George Gingerland"
     ],
+    "name:frr_x_preferred":[
+        "Saint George Gingerland"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a9c\u0acd\u0aaf\u0acb\u0ab0\u0acd\u0a9c \u0a9c\u0abf\u0a82\u0a9c\u0ab0\u0ab2\u0ac7\u0aa8\u0acd\u0aa1 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -91,6 +94,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc870\uc9c0\uc9c4\uc808\ub79c\ub4dc \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc870\uc9c0\uc9c4\uc808\ub79c\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eord\u017ea D\u017eind\u017eerlandes pagasts"
     ],
@@ -111,6 +117,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint George Gingerland prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint George Gingerland"
     ],
     "name:nor_x_preferred":[
         "Saint George Gingerland prestegjeld"
@@ -156,6 +165,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8056\u55ac\u6cbb\u91d1\u54f2\u862d\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u5723\u4e54\u6cbb\u91d1\u6770\u5170\u533a"
     ],
     "ne:abbrev":"GGI",
     "ne:adm0_a3":"KNA",
@@ -278,7 +290,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501338,
+    "wof:lastmodified":1690938196,
     "wof:name":"Saint George Gingerland",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/31/85673131.geojson
+++ b/data/856/731/31/85673131.geojson
@@ -64,6 +64,9 @@
     "name:fra_x_preferred":[
         "Saint-James Windward"
     ],
+    "name:frr_x_preferred":[
+        "Saint James Windward"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a9c\u0ac7\u0aae\u0acd\u0ab8 \u0ab5\u0abf\u0aa8\u0acd\u0aa1\u0ab5\u0ab0\u0acd\u0aa1 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -91,6 +94,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc81c\uc784\uc2a4\uc708\ub4dc\uc6cc\ub4dc \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc81c\uc784\uc2a4\uc708\ub4dc\uc6cc\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eeimsa Vindvorda pagasts"
     ],
@@ -108,6 +114,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint James Windward prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint James Windward"
     ],
     "name:nor_x_preferred":[
         "Saint James Windward prestegjeld"
@@ -278,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501337,
+    "wof:lastmodified":1690938194,
     "wof:name":"Saint James Windward",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/35/85673135.geojson
+++ b/data/856/731/35/85673135.geojson
@@ -65,6 +65,9 @@
     "name:fra_x_preferred":[
         "Saint-John Capisterre"
     ],
+    "name:frr_x_preferred":[
+        "Saint John Capisterre"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a82\u0a9f \u0a9c\u0acd\u0ab9\u0acb\u0aa8 \u0a95\u0ac5\u0aaa\u0acd\u0aaa\u0ac0\u0a9f\u0ac7\u0ab0\u0ac7 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -92,6 +95,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc874\uce74\ud53c\uc2a4\ud14c\ub974 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc874\uce74\ud53c\uc2a4\ud14c\ub974\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eona Kaspitera pagasts"
     ],
@@ -112,6 +118,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint John Capisterre prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint John Capisterre"
     ],
     "name:nor_x_preferred":[
         "Saint John Capisterre prestegjeld"
@@ -277,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501336,
+    "wof:lastmodified":1690938193,
     "wof:name":"Saint John Capesterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/39/85673139.geojson
+++ b/data/856/731/39/85673139.geojson
@@ -64,6 +64,9 @@
     "name:fra_x_preferred":[
         "Saint-John Figtree"
     ],
+    "name:frr_x_preferred":[
+        "Saint John Figtree"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a9c\u0acd\u0ab9\u0acb\u0aa8 \u0aab\u0abf\u0a97\u0a9f\u0acd\u0ab0\u0ac0 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -91,6 +94,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc874\ud53c\uadf8\ud2b8\ub9ac \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc874\ud53c\uadf8\ud2b8\ub9ac\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eona Figtr\u012b pagasts"
     ],
@@ -108,6 +114,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint John Figtree prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint John Figtree"
     ],
     "name:nor_x_preferred":[
         "Saint John Figtree prestegjeld"
@@ -278,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501337,
+    "wof:lastmodified":1690938195,
     "wof:name":"Saint John Figtree",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/43/85673143.geojson
+++ b/data/856/731/43/85673143.geojson
@@ -64,6 +64,9 @@
     "name:fra_x_preferred":[
         "Saint-Mary Cayon"
     ],
+    "name:frr_x_preferred":[
+        "Saint Mary Cayon"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aae\u0ac7\u0ab0\u0ac0 \u0a95\u0ac7\u0aaf\u0abe\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -91,6 +94,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uba54\ub9ac\uce74\uc698 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uba54\ub9ac\uce74\uc698\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentmer\u012b Keionas pagasts"
     ],
@@ -108,6 +114,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Mary Cayon prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Mary Cayon"
     ],
     "name:nor_x_preferred":[
         "Saint Mary Cayon prestegjeld"
@@ -275,7 +284,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501337,
+    "wof:lastmodified":1690938194,
     "wof:name":"Saint Mary Cayon",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/47/85673147.geojson
+++ b/data/856/731/47/85673147.geojson
@@ -65,6 +65,9 @@
     "name:fra_x_preferred":[
         "Saint-Paul Capisterre"
     ],
+    "name:frr_x_preferred":[
+        "Saint Paul Capisterre"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aaa\u0acc\u0ab2 \u0a95\u0ac5\u0aaa\u0abf\u0ab8\u0acd\u0a9f\u0ac7\u0ab0\u0ac7 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -92,6 +95,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud3f4\uce74\ud53c\uc2a4\ud14c\ub974 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud3f4\uce74\ud53c\uc2a4\ud14c\ub974\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentpola Kaspitera pagasts"
     ],
@@ -109,6 +115,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Paul Capisterre prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Paul Capisterre"
     ],
     "name:nor_x_preferred":[
         "Saint Paul Capisterre prestegjeld"
@@ -280,7 +289,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501338,
+    "wof:lastmodified":1690938195,
     "wof:name":"Saint Paul Capesterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/53/85673153.geojson
+++ b/data/856/731/53/85673153.geojson
@@ -35,6 +35,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u09aa\u09b2 \u099a\u09be\u09b0\u09cd\u09b2\u09b8\u09b8\u09cd\u099f\u09be\u0993\u09af\u09bc\u09be\u09b0 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
+    "name:ben_x_variant":[
+        "\u09b8\u09c7\u09a8\u09cd\u099f \u09aa\u09b2 \u099a\u09be\u09b0\u09cd\u09b2\u09b8\u099f\u09be\u0989\u09a8 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
+    ],
     "name:ceb_x_preferred":[
         "Saint Paul Charlestown"
     ],
@@ -64,6 +67,9 @@
     "name:fra_x_preferred":[
         "Saint-Paul Charlestown"
     ],
+    "name:frr_x_preferred":[
+        "Saint Paul Charlestown"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aaa\u0acc\u0ab2 \u0a9a\u0abe\u0ab0\u0acd\u0ab2\u0acd\u0ab8\u0a9f\u0abe\u0a89\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -91,6 +97,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud3f4\ucc30\uc2a4\ud0c0\uc6b4 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud3f4\ucc30\uc2a4\ud0c0\uc6b4\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentpola \u010c\u0101rlstaunas pagasts"
     ],
@@ -108,6 +117,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Paul Charlestown prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Paul Charlestown"
     ],
     "name:nor_x_preferred":[
         "Saint Paul Charlestown prestegjeld"
@@ -132,6 +144,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd \u0baa\u0bbe\u0bb2\u0bcd \u0b9a\u0bbe\u0bb0\u0bcd\u0bb2\u0bb8\u0bcd\u0ba8\u0b95\u0bb0\u0bae\u0bcd  \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd \u0baa\u0bbe\u0bb2\u0bcd \u0b9a\u0bbe\u0bb0\u0bcd\u0bb2\u0bb8\u0bcd\u0ba8\u0b95\u0bb0\u0bae\u0bcd \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c2a\u0c3e\u0c32\u0c4d \u0c1a\u0c3e\u0c30\u0c4d\u0c32\u0c46\u0c38\u0c4d\u200c\u0c1f\u0c4c\u0c28\u0c4d \u0c2a\u0c3e\u0c30\u0c3f\u0c37\u0c4d"
@@ -275,7 +290,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501337,
+    "wof:lastmodified":1690938195,
     "wof:name":"Saint Paul Charlestown",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/57/85673157.geojson
+++ b/data/856/731/57/85673157.geojson
@@ -64,6 +64,9 @@
     "name:fra_x_preferred":[
         "Saint-Peter Basseterre"
     ],
+    "name:frr_x_preferred":[
+        "Saint Peter Basseterre"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aaa\u0ac0\u0a9f\u0ab0 \u0aac\u0abe\u0ab8\u0ac7\u0a9f\u0ac7\u0ab0\u0ac7 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -91,6 +94,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud53c\ud130\ubc14\uc2a4\ud14c\ub974 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud53c\ud130\ubc14\uc2a4\ud14c\ub974\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentp\u012btera Bastera pagasts"
     ],
@@ -108,6 +114,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Peter Basseterre prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Peter Basseterre"
     ],
     "name:nor_x_preferred":[
         "Saint Peter Basseterre prestegjeld"
@@ -275,7 +284,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501336,
+    "wof:lastmodified":1690938193,
     "wof:name":"Saint Peter Basseterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/61/85673161.geojson
+++ b/data/856/731/61/85673161.geojson
@@ -64,6 +64,9 @@
     "name:fra_x_preferred":[
         "Saint-Thomas Lowland"
     ],
+    "name:frr_x_preferred":[
+        "Saint Thomas Lowland"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aa5\u0acb\u0aae\u0ab8 \u0ab2\u0acb\u0ab2\u0ac7\u0a82\u0aa1 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -91,6 +94,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud1a0\uba38\uc2a4\ub864\ub7f0\ub4dc \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud1a0\uba38\uc2a4\ub864\ub7f0\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Senttomasa Lovlandas pagasts"
     ],
@@ -108,6 +114,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Thomas Lowland prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Thomas Lowland"
     ],
     "name:nor_x_preferred":[
         "Saint Thomas Lowland prestegjeld"
@@ -275,7 +284,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501336,
+    "wof:lastmodified":1690938192,
     "wof:name":"Saint Thomas Lowland",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/63/85673163.geojson
+++ b/data/856/731/63/85673163.geojson
@@ -65,6 +65,9 @@
     "name:fra_x_preferred":[
         "Saint-Thomas Middle Island"
     ],
+    "name:frr_x_preferred":[
+        "Saint Thomas Middle Island"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aa5\u0acb\u0aae\u0ab8 \u0aae\u0abf\u0aa1\u0ab2 \u0a86\u0a87\u0ab2\u0ac7\u0aa8\u0acd\u0aa1 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Thomas Middle Island prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Thomas Middle Island"
     ],
     "name:nor_x_preferred":[
         "Saint Thomas Middle Island prestegjeld"
@@ -276,7 +282,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501338,
+    "wof:lastmodified":1690938195,
     "wof:name":"Saint Thomas Middle Island",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/67/85673167.geojson
+++ b/data/856/731/67/85673167.geojson
@@ -62,6 +62,9 @@
     "name:fra_x_preferred":[
         "Trinity Palmetto Point"
     ],
+    "name:frr_x_preferred":[
+        "Trinity Palmetto Point"
+    ],
     "name:guj_x_preferred":[
         "\u0a9f\u0acd\u0ab0\u0abf\u0aa8\u0abf\u0a9f\u0ac0 \u0aaa\u0abe\u0ab2\u0acd\u0aae\u0ac7\u0a9f\u0acb \u0aaa\u0acb\u0a87\u0aa8\u0acd\u0a9f \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -89,6 +92,9 @@
     "name:kor_x_preferred":[
         "\ud2b8\ub9ac\ub2c8\ud2f0\ud330\uba38\ud1a0\ud3ec\uc778\ud2b8 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud2b8\ub9ac\ub2c8\ud2f0\ud330\uba38\ud1a0\ud3ec\uc778\ud2b8\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Triniti Palmetopointas pagasts"
     ],
@@ -109,6 +115,9 @@
     ],
     "name:nob_x_preferred":[
         "Trinity Palmetto Point prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Trinity Palmetto Point"
     ],
     "name:nor_x_preferred":[
         "Trinity Palmetto Point prestegjeld"
@@ -276,7 +285,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501336,
+    "wof:lastmodified":1690938193,
     "wof:name":"Trinity Palmetto Point",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/890/430/731/890430731.geojson
+++ b/data/890/430/731/890430731.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u064a\u0628 \u0628\u0627\u064a \u062a\u0627\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u064a\u0628 \u0628\u0627\u0649 \u062a\u0627\u0648\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Dieppe Bay Town"
+    ],
     "name:ceb_x_preferred":[
         "Dieppe Bay Town"
     ],
@@ -33,6 +39,9 @@
     ],
     "name:fas_x_preferred":[
         "\u062f\u06cc\u067e \u0628\u06cc \u062a\u0627\u0648\u0646"
+    ],
+    "name:ita_x_preferred":[
+        "Dieppe Bay Town"
     ],
     "name:jpn_x_preferred":[
         "\u30c7\u30a3\u30a8\u30c3\u30d7\u30d9\u30a4\u30bf\u30a6\u30f3"
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":890430731,
-    "wof:lastmodified":1566581621,
+    "wof:lastmodified":1690938199,
     "wof:name":"Dieppe Bay Town",
     "wof:parent_id":85673135,
     "wof:placetype":"locality",

--- a/data/890/431/937/890431937.geojson
+++ b/data/890/431/937/890431937.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062f\u064a \u0628\u0648\u064a\u0646\u062a \u062a\u0627\u0648\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Sandy Point Town"
+    ],
     "name:ceb_x_preferred":[
         "Sandy Point Town"
     ],
@@ -31,8 +34,14 @@
     "name:eng_x_preferred":[
         "Sandy Point Town"
     ],
+    "name:fra_x_preferred":[
+        "Sandy Point Town"
+    ],
     "name:heb_x_preferred":[
         "\u05e1\u05e0\u05d3\u05d9 \u05e4\u05d5\u05d9\u05e0\u05d8"
+    ],
+    "name:ita_x_preferred":[
+        "Sandy Point Town"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\u30c7\u30a3\u30fb\u30dd\u30a4\u30f3\u30c8"
@@ -45,6 +54,9 @@
     ],
     "name:pol_x_preferred":[
         "Sandy Point"
+    ],
+    "name:por_x_preferred":[
+        "Sandy Point Town"
     ],
     "name:rus_x_preferred":[
         "\u0421\u044d\u043d\u0434\u0438-\u041f\u043e\u0439\u043d\u0442-\u0422\u0430\u0443\u043d"
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":890431937,
-    "wof:lastmodified":1566581621,
+    "wof:lastmodified":1690938200,
     "wof:name":"Sandy Point Town",
     "wof:parent_id":85673117,
     "wof:placetype":"locality",

--- a/data/890/440/079/890440079.geojson
+++ b/data/890/440/079/890440079.geojson
@@ -33,11 +33,23 @@
     "name:arg_x_preferred":[
         "Basseterre"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u0627\u0633 \u0637\u064a\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0633\u062a\u064a\u0631"
+    ],
     "name:ast_x_preferred":[
+        "Basseterre"
+    ],
+    "name:avk_x_preferred":[
         "Basseterre"
     ],
     "name:aze_x_preferred":[
         "Baster"
+    ],
+    "name:ban_x_preferred":[
+        "Basseterre"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0430\u0441\u0442\u044d\u0440"
@@ -114,6 +126,9 @@
     "name:fra_x_preferred":[
         "Basseterre"
     ],
+    "name:frr_x_preferred":[
+        "Basseterre"
+    ],
     "name:fry_x_preferred":[
         "Basseterre"
     ],
@@ -147,6 +162,9 @@
     "name:hin_x_preferred":[
         "\u092c\u0947\u0938\u0947\u0924\u094d\u0930\u0940"
     ],
+    "name:hin_x_variant":[
+        "\u092c\u093e\u0938\u0947\u091f\u0947\u092f\u0930"
+    ],
     "name:hrv_x_preferred":[
         "Basseterre"
     ],
@@ -163,6 +181,9 @@
         "Basseterre"
     ],
     "name:ind_x_preferred":[
+        "Basseterre"
+    ],
+    "name:isl_x_preferred":[
         "Basseterre"
     ],
     "name:ita_x_preferred":[
@@ -185,6 +206,9 @@
     ],
     "name:lav_x_preferred":[
         "Bastera"
+    ],
+    "name:lij_x_preferred":[
+        "Basseterre"
     ],
     "name:lit_x_preferred":[
         "Basteras"
@@ -240,6 +264,9 @@
     "name:por_x_preferred":[
         "Basseterre"
     ],
+    "name:pus_x_preferred":[
+        "\u0628\u0627\u0633\u062a\u0631"
+    ],
     "name:ron_x_preferred":[
         "Basseterre"
     ],
@@ -264,6 +291,9 @@
     "name:spa_x_preferred":[
         "Basseterre"
     ],
+    "name:srd_x_preferred":[
+        "Basseterre"
+    ],
     "name:srp_x_preferred":[
         "\u0411\u0430\u0441\u0442\u0435\u0440"
     ],
@@ -282,6 +312,9 @@
     "name:tam_x_preferred":[
         "\u0baa\u0bbe\u0b9a\u0bc6\u0b9f\u0bcd\u0b9f\u0bc6\u0bb0\u0bc7"
     ],
+    "name:tgk_x_preferred":[
+        "\u0411\u0430\u0441\u0442\u0435\u0440"
+    ],
     "name:tgl_x_preferred":[
         "Basseterre"
     ],
@@ -290,6 +323,9 @@
     ],
     "name:tur_x_preferred":[
         "Basseterre"
+    ],
+    "name:udm_x_preferred":[
+        "\u0411\u0430\u0441\u0442\u0435\u0440"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u0430\u0441\u0442\u0435\u0440"
@@ -311,6 +347,9 @@
     ],
     "name:war_x_preferred":[
         "Basseterre"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5df4\u65af\u7279\u5c14"
     ],
     "name:xmf_x_preferred":[
         "\u10d1\u10d0\u10e1\u10e2\u10d4\u10e0\u10d8"
@@ -466,7 +505,7 @@
         }
     ],
     "wof:id":890440079,
-    "wof:lastmodified":1636501339,
+    "wof:lastmodified":1690938199,
     "wof:name":"Basseterre",
     "wof:parent_id":85673167,
     "wof:placetype":"locality",

--- a/data/890/455/319/890455319.geojson
+++ b/data/890/455/319/890455319.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u064a\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u064a\u0648\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Cayon"
+    ],
     "name:ceb_x_preferred":[
         "Cayon"
     ],
@@ -42,6 +48,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d0\u05d9\u05d5\u05df"
+    ],
+    "name:ita_x_preferred":[
+        "Cayon"
     ],
     "name:jpn_x_preferred":[
         "\u30b1\u30a4\u30aa\u30f3"
@@ -107,7 +116,7 @@
         }
     ],
     "wof:id":890455319,
-    "wof:lastmodified":1566581621,
+    "wof:lastmodified":1690938200,
     "wof:name":"Cayon",
     "wof:parent_id":85673143,
     "wof:placetype":"locality",

--- a/data/890/455/321/890455321.geojson
+++ b/data/890/455/321/890455321.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Boyds"
     ],
+    "name:jpn_x_preferred":[
+        "\u30dc\u30a4\u30ba"
+    ],
     "name:nld_x_preferred":[
         "Boyds"
     ],
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":890455321,
-    "wof:lastmodified":1566581621,
+    "wof:lastmodified":1690938200,
     "wof:name":"Boyd\u2019s",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.