### PR TITLE
kn concordances, placetype local, and more

### DIFF
--- a/data/856/325/51/85632551.geojson
+++ b/data/856/325/51/85632551.geojson
@@ -1160,6 +1160,7 @@
         "gp:id":23424940,
         "hasc:id":"KN",
         "ioc:id":"SKN",
+        "iso:code":"KN",
         "itu:id":"KNA",
         "loc:id":"n81008539",
         "m49:code":"659",
@@ -1174,6 +1175,7 @@
         "wk:page":"Saint Kitts and Nevis",
         "wmo:id":"AT"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
     "wof:country_alpha3":"KNA",
     "wof:geom_alt":[
@@ -1194,7 +1196,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639532,
+    "wof:lastmodified":1695881189,
     "wof:name":"Saint Kitts and Nevis",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/731/11/85673111.geojson
+++ b/data/856/731/11/85673111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001803,
-    "geom:area_square_m":21283105.047883,
+    "geom:area_square_m":21283229.421724,
     "geom:bbox":"-62.787509,17.331033,-62.730509,17.386997",
     "geom:latitude":17.356413,
     "geom:longitude":-62.761057,
@@ -263,14 +263,16 @@
         "gn:id":3575476,
         "gp:id":2346964,
         "hasc:id":"KN.CC",
+        "iso:code":"KN-01",
         "iso:id":"KN-01",
         "qs_pg:id":232241,
         "unlc:id":"KN-01",
         "wd:id":"Q176164",
         "wk:page":"Christ Church Nichola Town Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"b5e7fdf4fa21aa2900b001c43f58602d",
+    "wof:geomhash":"be007a09ac723bdd6d469f4d757fecf8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938193,
+    "wof:lastmodified":1695884882,
     "wof:name":"Christ Church Nichola Town",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/17/85673117.geojson
+++ b/data/856/731/17/85673117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001406,
-    "geom:area_square_m":16597761.474866,
+    "geom:area_square_m":16597539.000724,
     "geom:bbox":"-62.861073,17.330146,-62.807619,17.382283",
     "geom:latitude":17.359219,
     "geom:longitude":-62.836575,
@@ -265,14 +265,16 @@
         "gn:id":3575183,
         "gp:id":2346965,
         "hasc:id":"KN.AS",
+        "iso:code":"KN-02",
         "iso:id":"KN-02",
         "qs_pg:id":1311700,
         "unlc:id":"KN-02",
         "wd:id":"Q1473654",
         "wk:page":"Saint Anne Sandy Point Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"eece9c7a1d4088ab5f0b57222c76ff65",
+    "wof:geomhash":"7f78265d69f98d1ee07e9718d3e4cd5b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938194,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint Anne Sandy Point",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/21/85673121.geojson
+++ b/data/856/731/21/85673121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002972,
-    "geom:area_square_m":35097125.326173,
+    "geom:area_square_m":35096737.286703,
     "geom:bbox":"-62.734313,17.21719,-62.624745,17.320654",
     "geom:latitude":17.266081,
     "geom:longitude":-62.67127,
@@ -271,14 +271,16 @@
         "gn:id":3575180,
         "gp:id":2346966,
         "hasc:id":"KN.GB",
+        "iso:code":"KN-03",
         "iso:id":"KN-03",
         "qs_pg:id":1114945,
         "unlc:id":"KN-03",
         "wd:id":"Q1540744",
         "wk:page":"Saint George Basseterre Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"648b15ef913c44f5c789236599afbf73",
+    "wof:geomhash":"b87daf78a3a22f9b64dac94619758bc3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938194,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint George Basseterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/25/85673125.geojson
+++ b/data/856/731/25/85673125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001438,
-    "geom:area_square_m":16995737.58214,
+    "geom:area_square_m":16995793.41957,
     "geom:bbox":"-62.578619,17.100531,-62.536773,17.150039",
     "geom:latitude":17.126974,
     "geom:longitude":-62.556908,
@@ -268,14 +268,16 @@
         "gn:id":3575179,
         "gp:id":2346967,
         "hasc:id":"KN.GG",
+        "iso:code":"KN-04",
         "iso:id":"KN-04",
         "qs_pg:id":1168745,
         "unlc:id":"KN-04",
         "wd:id":"Q1472520",
         "wk:page":"Saint George Gingerland Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"5b708921de2bbec94c894e0886d58dc5",
+    "wof:geomhash":"45752892c806922814773a0c4c23acb2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -290,7 +292,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938196,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint George Gingerland",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/31/85673131.geojson
+++ b/data/856/731/31/85673131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00276,
-    "geom:area_square_m":32601587.128541,
+    "geom:area_square_m":32601350.863699,
     "geom:bbox":"-62.61255,17.138393,-62.536956,17.202948",
     "geom:latitude":17.174367,
     "geom:longitude":-62.570441,
@@ -265,14 +265,16 @@
         "gn:id":3575177,
         "gp:id":2346968,
         "hasc:id":"KN.JW",
+        "iso:code":"KN-05",
         "iso:id":"KN-05",
         "qs_pg:id":1168746,
         "unlc:id":"KN-05",
         "wd:id":"Q1342139",
         "wk:page":"Saint James Windward Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"fb74ae6c696857fc807c3816e4b65752",
+    "wof:geomhash":"beed89840012409786b6eaa9dfd73d70",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938194,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint James Windward",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/35/85673135.geojson
+++ b/data/856/731/35/85673135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001806,
-    "geom:area_square_m":21313849.916433,
+    "geom:area_square_m":21314095.888016,
     "geom:bbox":"-62.822336,17.349846,-62.769423,17.415839",
     "geom:latitude":17.382957,
     "geom:longitude":-62.797126,
@@ -265,13 +265,15 @@
         "gn:id":3575176,
         "gp:id":2346969,
         "hasc:id":"KN.JC",
+        "iso:code":"KN-06",
         "iso:id":"KN-06",
         "qs_pg:id":1168747,
         "wd:id":"Q668498",
         "wk:page":"Saint John Capisterre Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"8f2e79815857f848d0fd949e12b5b997",
+    "wof:geomhash":"bd1074c847f9ab3198dbb9c4921e1b29",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -286,7 +288,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938193,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint John Capesterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/39/85673139.geojson
+++ b/data/856/731/39/85673139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001445,
-    "geom:area_square_m":17077711.201885,
+    "geom:area_square_m":17077550.444729,
     "geom:bbox":"-62.621567,17.100531,-62.565745,17.145498",
     "geom:latitude":17.118354,
     "geom:longitude":-62.591691,
@@ -265,14 +265,16 @@
         "gn:id":3575175,
         "gp:id":2346970,
         "hasc:id":"KN.JF",
+        "iso:code":"KN-07",
         "iso:id":"KN-07",
         "qs_pg:id":231519,
         "unlc:id":"KN-07",
         "wd:id":"Q657318",
         "wk:page":"Saint John Figtree Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"3e1039b43099569d02ed37a50705d896",
+    "wof:geomhash":"3f8d518989be2298f5ee9a41332b6451",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938195,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint John Figtree",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/43/85673143.geojson
+++ b/data/856/731/43/85673143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000814,
-    "geom:area_square_m":9602401.637844,
+    "geom:area_square_m":9602278.595957,
     "geom:bbox":"-62.74599,17.330385,-62.703561,17.364614",
     "geom:latitude":17.346968,
     "geom:longitude":-62.728415,
@@ -262,14 +262,16 @@
         "gn:id":3575173,
         "gp:id":2346971,
         "hasc:id":"KN.MC",
+        "iso:code":"KN-08",
         "iso:id":"KN-08",
         "qs_pg:id":231520,
         "unlc:id":"KN-08",
         "wd:id":"Q1538034",
         "wk:page":"Saint Mary Cayon Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"2f2c79d9ee4990a14e7b957ac2ec9dc8",
+    "wof:geomhash":"646af7230ee23b83f80111ccf4ba874e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938194,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint Mary Cayon",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/47/85673147.geojson
+++ b/data/856/731/47/85673147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001073,
-    "geom:area_square_m":12665156.982697,
+    "geom:area_square_m":12665265.722232,
     "geom:bbox":"-62.856636,17.366713,-62.807619,17.410102",
     "geom:latitude":17.387679,
     "geom:longitude":-62.832398,
@@ -268,13 +268,15 @@
         "gn:id":3575172,
         "gp:id":2346972,
         "hasc:id":"KN.PP",
+        "iso:code":"KN-09",
         "iso:id":"KN-09",
         "qs_pg:id":1097074,
         "wd:id":"Q952735",
         "wk:page":"Saint Paul Capisterre Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"5972c6dfa9d3ea141824315c297c9477",
+    "wof:geomhash":"7af388b5dd76859e043e1e759729b035",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -289,7 +291,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938195,
+    "wof:lastmodified":1695884883,
     "wof:name":"Saint Paul Capesterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/53/85673153.geojson
+++ b/data/856/731/53/85673153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000355,
-    "geom:area_square_m":4197520.045575,
+    "geom:area_square_m":4197358.577369,
     "geom:bbox":"-62.626373,17.128328,-62.578619,17.145498",
     "geom:latitude":17.135431,
     "geom:longitude":-62.606569,
@@ -268,14 +268,16 @@
         "gn:id":3575171,
         "gp:id":2346973,
         "hasc:id":"KN.PL",
+        "iso:code":"KN-10",
         "iso:id":"KN-10",
         "qs_pg:id":1311699,
         "unlc:id":"KN-10",
         "wd:id":"Q1752127",
         "wk:page":"Saint Paul Charlestown Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"a9ed81908b62b8dfbd1f34ff3f5d4f90",
+    "wof:geomhash":"19428360202ca708a267bc89b30d39cc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -290,7 +292,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938195,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint Paul Charlestown",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/57/85673157.geojson
+++ b/data/856/731/57/85673157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001276,
-    "geom:area_square_m":15058607.519539,
+    "geom:area_square_m":15058703.537527,
     "geom:bbox":"-62.738206,17.298597,-62.681164,17.341604",
     "geom:latitude":17.322198,
     "geom:longitude":-62.709222,
@@ -262,14 +262,16 @@
         "gn:id":3575168,
         "gp:id":2346974,
         "hasc:id":"KN.PB",
+        "iso:code":"KN-11",
         "iso:id":"KN-11",
         "qs_pg:id":235637,
         "unlc:id":"KN-11",
         "wd:id":"Q1725609",
         "wk:page":"Saint Peter Basseterre Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"5892d4390275a8feb026047544895ad5",
+    "wof:geomhash":"d398c36b2c317881a15f50364f84d8cd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938193,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint Peter Basseterre",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/61/85673161.geojson
+++ b/data/856/731/61/85673161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001525,
-    "geom:area_square_m":18019721.44631,
+    "geom:area_square_m":18020133.719248,
     "geom:bbox":"-62.626373,17.138362,-62.578619,17.189129",
     "geom:latitude":17.159251,
     "geom:longitude":-62.605162,
@@ -262,14 +262,16 @@
         "gn:id":3575165,
         "gp:id":2346975,
         "hasc:id":"KN.TL",
+        "iso:code":"KN-12",
         "iso:id":"KN-12",
         "qs_pg:id":219612,
         "unlc:id":"KN-12",
         "wd:id":"Q1752122",
         "wk:page":"Saint Thomas Lowland Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"ac9d9cb42b63de6ffc4f51c0891c3673",
+    "wof:geomhash":"9f22285d2af181ee090daa39d502ec12",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938192,
+    "wof:lastmodified":1695884882,
     "wof:name":"Saint Thomas Lowland",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/63/85673163.geojson
+++ b/data/856/731/63/85673163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002522,
-    "geom:area_square_m":29770553.088664,
+    "geom:area_square_m":29770100.214311,
     "geom:bbox":"-62.831614,17.298017,-62.754424,17.366713",
     "geom:latitude":17.330263,
     "geom:longitude":-62.793756,
@@ -260,14 +260,16 @@
         "gn:id":3575164,
         "gp:id":2346976,
         "hasc:id":"KN.TM",
+        "iso:code":"KN-13",
         "iso:id":"KN-13",
         "qs_pg:id":1047392,
         "unlc:id":"KN-13",
         "wd:id":"Q1752101",
         "wk:page":"Saint Thomas Middle Island Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"1d7124339581451d8a3d849b96465747",
+    "wof:geomhash":"40f49ab6e323222f189fa3a054b54a33",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -282,7 +284,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938195,
+    "wof:lastmodified":1695884883,
     "wof:name":"Saint Thomas Middle Island",
     "wof:parent_id":85632551,
     "wof:placetype":"region",

--- a/data/856/731/67/85673167.geojson
+++ b/data/856/731/67/85673167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001248,
-    "geom:area_square_m":14733842.137924,
+    "geom:area_square_m":14733793.548592,
     "geom:bbox":"-62.771625,17.290595,-62.723805,17.331033",
     "geom:latitude":17.308218,
     "geom:longitude":-62.747582,
@@ -263,14 +263,16 @@
         "gn:id":3575114,
         "gp:id":2346977,
         "hasc:id":"KN.TP",
+        "iso:code":"KN-15",
         "iso:id":"KN-15",
         "qs_pg:id":1047393,
         "unlc:id":"KN-15",
         "wd:id":"Q376738",
         "wk:page":"Trinity Palmetto Point Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KN",
-    "wof:geomhash":"1b9b9a7b7104753d9b542beef870b4b8",
+    "wof:geomhash":"36571da8fe309a9cd89e36f7209bd7cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938193,
+    "wof:lastmodified":1695884882,
     "wof:name":"Trinity Palmetto Point",
     "wof:parent_id":85632551,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.